### PR TITLE
Add support for tracker namespace

### DIFF
--- a/snowplowtrk.go
+++ b/snowplowtrk.go
@@ -66,6 +66,11 @@ func main() {
 			Value: appName,
 		},
 		cli.StringFlag{
+			Name:  "namespace, ns",
+			Usage: "Tracker Namespace (Optional)",
+			Value: appName,
+		},
+		cli.StringFlag{
 			Name:  "method, m",
 			Usage: "Method[POST|GET] (Optional)",
 			Value: "GET",
@@ -103,6 +108,7 @@ func main() {
 	app.Action = func(c *cli.Context) error {
 		collector := c.String("collector")
 		appid := c.String("appid")
+		namespace := c.String("namespace")
 		method := c.String("method")
 		protocol := c.String("protocol")
 		sdjson := c.String("sdjson")
@@ -132,7 +138,7 @@ func main() {
 		trackerChan := make(chan int, 1)
 
 		// Send the event
-		tracker := initTracker(collector, appid, method, protocol, ipAddress, trackerChan, nil)
+		tracker := initTracker(collector, appid, namespace, method, protocol, ipAddress, trackerChan, nil)
 		statusCode := trackSelfDescribingEvent(tracker, trackerChan, sdj, contextArr)
 
 		// Parse return code
@@ -203,7 +209,7 @@ func getContexts(contexts string) ([]gt.SelfDescribingJson, error) {
 
 // initTracker creates a new Tracker ready for use
 // by the application.
-func initTracker(collector string, appid string, method string, protocol string, ipAddress string, trackerChan chan int, httpClient *http.Client) *gt.Tracker {
+func initTracker(collector string, appid string, namespace string, method string, protocol string, ipAddress string, trackerChan chan int, httpClient *http.Client) *gt.Tracker {
 
 	// Create callback function
 	callback := func(s []gt.CallbackResult, f []gt.CallbackResult) {
@@ -234,6 +240,7 @@ func initTracker(collector string, appid string, method string, protocol string,
 		gt.RequireEmitter(emitter),
 		gt.OptionSubject(subject),
 		gt.OptionAppId(appid),
+		gt.OptionNamespace(namespace),
 	)
 
 	return tracker

--- a/snowplowtrk_test.go
+++ b/snowplowtrk_test.go
@@ -95,11 +95,12 @@ func TestInitTracker(t *testing.T) {
 	assert := assert.New(t)
 	trackerChan := make(chan int, 1)
 
-	tracker := initTracker("com.acme", "myapp", "POST", "https", "", trackerChan, nil)
+	tracker := initTracker("com.acme", "myapp", "mynamespace", "POST", "https", "", trackerChan, nil)
 	assert.NotNil(tracker)
 	assert.NotNil(tracker.Emitter)
 	assert.NotNil(tracker.Subject)
 	assert.Equal("myapp", tracker.AppId)
+	assert.Equal("mynamespace", tracker.Namespace)
 }
 
 func TestTrackSelfDescribingEventGood(t *testing.T) {
@@ -124,7 +125,7 @@ func TestTrackSelfDescribingEventGood(t *testing.T) {
 
 	// Setup Tracker
 	trackerChan := make(chan int, 1)
-	tracker := initTracker("com.acme", "myapp", "GET", "http", "", trackerChan, httpClient)
+	tracker := initTracker("com.acme", "myapp", "mynamespace", "GET", "http", "", trackerChan, httpClient)
 	assert.NotNil(tracker)
 
 	// Make SDJ
@@ -163,7 +164,7 @@ func TestTrackSelfDescribingEventBad(t *testing.T) {
 
 	// Setup Tracker
 	trackerChan := make(chan int, 1)
-	tracker := initTracker("com.acme", "myapp", "POST", "http", "", trackerChan, httpClient)
+	tracker := initTracker("com.acme", "myapp", "mynamespace", "POST", "http", "", trackerChan, httpClient)
 	assert.NotNil(tracker)
 
 	// Make SDJ


### PR DESCRIPTION
Our Snowplow setup routes events by namespace, so we need to be able to add this field. The Golang tracker already supports it, so it's just a matter of adding the flag.